### PR TITLE
Don't always print socket exception to console

### DIFF
--- a/common/src/main/java/org/jspace/SpaceRepository.java
+++ b/common/src/main/java/org/jspace/SpaceRepository.java
@@ -127,11 +127,13 @@ public class SpaceRepository {
 					addHandler( handler );
 				}
 			} catch (IOException e) {
-				e.printStackTrace();
-				try {
-					gate.close();
-				} catch (IOException e1) {
-					e1.printStackTrace();
+				if (!gate.isClosed()) {
+					e.printStackTrace();
+					try {
+						gate.close();
+					} catch (IOException e1) {
+						e1.printStackTrace();
+					}	
 				}
 			}
 		});

--- a/common/src/main/java/org/jspace/gate/ConnServerGate.java
+++ b/common/src/main/java/org/jspace/gate/ConnServerGate.java
@@ -66,6 +66,11 @@ public class ConnServerGate implements ServerGate {
 			this.ssocket.close();
 		}
 	}
+	
+	@Override
+	public boolean isClosed() {
+		return this.ssocket.isClosed();
+	}
 
 	@Override
 	public URI getURI() {
@@ -76,5 +81,4 @@ public class ConnServerGate implements ServerGate {
 			return null;
 		}
 	}
-
 }

--- a/common/src/main/java/org/jspace/gate/ConnServerGate.java
+++ b/common/src/main/java/org/jspace/gate/ConnServerGate.java
@@ -42,6 +42,7 @@ public class ConnServerGate implements ServerGate {
 	private final InetSocketAddress address;
 	private final int backlog;
 	private ServerSocket ssocket;
+	private boolean isOpen = false;
 	
 	public ConnServerGate(jSpaceMarshaller marshaller, InetSocketAddress address, int backlog) {
 		this.address = address;
@@ -52,6 +53,7 @@ public class ConnServerGate implements ServerGate {
 
 	@Override
 	public void open() throws IOException {
+		this.isOpen = true;
 		this.ssocket = new ServerSocket(address.getPort(), backlog, address.getAddress());
 	}
 
@@ -62,6 +64,7 @@ public class ConnServerGate implements ServerGate {
 
 	@Override
 	public void close() throws IOException {
+		this.isOpen = false;
 		if (this.ssocket != null) {
 			this.ssocket.close();
 		}
@@ -69,7 +72,7 @@ public class ConnServerGate implements ServerGate {
 	
 	@Override
 	public boolean isClosed() {
-		return this.ssocket.isClosed();
+		return !this.isOpen;
 	}
 
 	@Override

--- a/common/src/main/java/org/jspace/gate/KeepServerGate.java
+++ b/common/src/main/java/org/jspace/gate/KeepServerGate.java
@@ -42,6 +42,7 @@ public class KeepServerGate implements ServerGate {
 	private InetSocketAddress address;
 	private int backlog;
 	private ServerSocket ssocket;
+	private boolean isOpen = false;
 	
 	public KeepServerGate(jSpaceMarshaller marshaller, InetSocketAddress address, int backlog) {
 		this.address = address;
@@ -52,6 +53,7 @@ public class KeepServerGate implements ServerGate {
 
 	@Override
 	public void open() throws IOException {
+		this.isOpen = true;
 		this.ssocket = new ServerSocket(address.getPort(), backlog, address.getAddress());
 	}
 
@@ -62,6 +64,7 @@ public class KeepServerGate implements ServerGate {
 
 	@Override
 	public void close() throws IOException {
+		this.isOpen = false;
 		if (this.ssocket != null) {
 			this.ssocket.close();		
 		}
@@ -69,7 +72,7 @@ public class KeepServerGate implements ServerGate {
 	
 	@Override
 	public boolean isClosed() {
-		return this.ssocket.isClosed();
+		return !this.isOpen;
 	}
 
 	@Override

--- a/common/src/main/java/org/jspace/gate/KeepServerGate.java
+++ b/common/src/main/java/org/jspace/gate/KeepServerGate.java
@@ -66,6 +66,11 @@ public class KeepServerGate implements ServerGate {
 			this.ssocket.close();		
 		}
 	}
+	
+	@Override
+	public boolean isClosed() {
+		return this.ssocket.isClosed();
+	}
 
 	@Override
 	public URI getURI() {

--- a/common/src/main/java/org/jspace/gate/ServerGate.java
+++ b/common/src/main/java/org/jspace/gate/ServerGate.java
@@ -38,6 +38,8 @@ public interface ServerGate {
 	
 	public void close( ) throws IOException;
 	
+	public boolean isClosed();
+	
 	public URI getURI();
 	
 }


### PR DESCRIPTION
socket.accept() in gate.accept() throws an error when the gate is closed but that was meant to happen when the gate is closed. Don't print to error to the console(and don't close an already closed gate) when it's already closed.