### PR TITLE
Fix QueryP and GetP for Tuples not present in the Space

### DIFF
--- a/common/src/main/java/org/jspace/SpaceRepository.java
+++ b/common/src/main/java/org/jspace/SpaceRepository.java
@@ -294,7 +294,7 @@ public class SpaceRepository {
 		}
 		if (t != null) {
 		    result.add(t);
-        }
+		}
 		return result;
 	}
 

--- a/common/src/main/java/org/jspace/SpaceRepository.java
+++ b/common/src/main/java/org/jspace/SpaceRepository.java
@@ -292,7 +292,9 @@ public class SpaceRepository {
 		} else {
 			t = space.getp(template.getFields());
 		}
-		result.add(t);
+		if (t != null) {
+		    result.add(t);
+        }
 		return result;
 	}
 
@@ -311,7 +313,9 @@ public class SpaceRepository {
 		} else {
 			t = space.queryp(template.getFields());
 		}
-		result.add(t);
+		if (t != null) {
+			result.add(t);
+		}
 		return result;
 	}
 

--- a/common/src/main/java/org/jspace/Tuple.java
+++ b/common/src/main/java/org/jspace/Tuple.java
@@ -146,7 +146,7 @@ public final class Tuple implements Iterable<Object>, Serializable {
 
 			@Override
 			public boolean hasNext() {
-				return fields != null && current < fields.length;
+				return current < fields.length;
 			}
 
 			@Override

--- a/common/src/main/java/org/jspace/Tuple.java
+++ b/common/src/main/java/org/jspace/Tuple.java
@@ -146,7 +146,7 @@ public final class Tuple implements Iterable<Object>, Serializable {
 
 			@Override
 			public boolean hasNext() {
-				return current < fields.length;
+				return fields != null && current < fields.length;
 			}
 
 			@Override


### PR DESCRIPTION
If QueryP or GetP is called for a Tuple that does not exist, the call is expected to return a null value (tutorial 1, section 1.6). If the Tuple does not exist, Tuple.hasNext() throws a NullPointerException, as the fields object is null. 

Furthermore, on Get or Query calls, the tuple t is added to the corresponding list of Tuples even if the object is null, resulting in the corresponding Tuple object returned by Space.Query/GetP technically not being null, but rather being an empty object.

Fixes #20 