### PR TITLE
Throws an exception if blocking operations call a non-existing remote space

### DIFF
--- a/common/src/main/java/org/jspace/RemoteSpace.java
+++ b/common/src/main/java/org/jspace/RemoteSpace.java
@@ -91,6 +91,7 @@ public class RemoteSpace implements Space {
 			//TODO: Replace with a specific exception
 			throw new InterruptedException(e.getMessage());
 		} 
+
 		if (response.isSuccessful()) {
 			List<Object[]> tuples = response.getTuples();
 			if (tuples.size()==0) {
@@ -98,6 +99,8 @@ public class RemoteSpace implements Space {
 			}
 			return tuples.get(0);
 		}
+
+		if (isBlocking) throw new InterruptedException("remote space does not exist!");
 		return null;
 	}
 
@@ -113,6 +116,7 @@ public class RemoteSpace implements Space {
 		if (response.isSuccessful()) {
 			return response.getTuples();
 		} 
+		
 		return null;		
 	}
 
@@ -134,6 +138,7 @@ public class RemoteSpace implements Space {
 		} catch (IOException e) {
 			throw new InterruptedException(e.getMessage());
 		} 
+
 		if (response.isSuccessful()) {
 			List<Object[]> tuples = response.getTuples();
 			if (tuples.size()==0) {
@@ -141,6 +146,8 @@ public class RemoteSpace implements Space {
 			}
 			return tuples.get(0);
 		}
+		
+		if (isBlocking) throw new InterruptedException("remote space does not exist!");
 		return null;
 	}
 

--- a/common/src/test/java/org/jspace/tests/TestRemoteSpace.java
+++ b/common/src/test/java/org/jspace/tests/TestRemoteSpace.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.net.UnknownHostException;
@@ -105,7 +106,13 @@ public class TestRemoteSpace {
 		Space aSpace = new SequentialSpace();
 		sr.add("target", aSpace);
 		RemoteSpace rs = new RemoteSpace("tcp://127.0.0.1:9990/another?keep");
-		assertNull(rs.get(new ActualField(1)));
+		
+		try {
+			rs.get(new ActualField(1));
+			fail();
+		} catch (InterruptedException e) {
+		}
+
 		sr.closeGates();
 	}
 
@@ -116,7 +123,11 @@ public class TestRemoteSpace {
 		Space aSpace = new SequentialSpace();
 		sr.add("target", aSpace);
 		RemoteSpace rs = new RemoteSpace("tcp://127.0.0.1:9990/another?keep");
-		assertNull(rs.query(new ActualField(1)));
+		try {
+			rs.query(new ActualField(1));
+			fail();
+		} catch (InterruptedException e) {
+		}
 		sr.closeGates();
 	}
 
@@ -220,5 +231,4 @@ public class TestRemoteSpace {
 		sr.addGate(uri);
 		sr.closeGate(uri);
 	}
-	
 }


### PR DESCRIPTION
The blocking operations "get" and "query" will now throw an exception if the remote space does not exist.