### PR TITLE
Fixed KEEP race condition

### DIFF
--- a/common/src/main/java/org/jspace/gate/KeepClientGate.java
+++ b/common/src/main/java/org/jspace/gate/KeepClientGate.java
@@ -68,13 +68,19 @@ public class KeepClientGate implements ClientGate {
 	
 	@Override
 	public ServerMessage send(ClientMessage m) throws IOException, InterruptedException {
-		String sessionId = ""+(sessionCounter++);
-		m.setTarget(target);
-		m.setClientSession(sessionId);
+		String sessionId;
+		
 		synchronized (outbox) {
+			sessionId = ""+sessionCounter;
+			sessionCounter++;
+			
+			m.setTarget(target);
+			m.setClientSession(sessionId);
+
 			outbox.add(m);
 			outbox.notify();
 		}
+		
 		return inbox.call(sessionId);
 	}
 


### PR DESCRIPTION
If multiple threads call get() on the same `RemoteSpace`, then  `sessionCounter++` can increment incorrectly, because the expression is non-atomic and outside the critical section.
The bug is a race-condition. Hence, the bug is triggered "randomly" and it will be not possible to create predictable JUnit tests.

A test which triggers the racecondition is shown below.
```java
import java.io.IOException;
import java.net.UnknownHostException;

import org.jspace.ActualField;
import org.jspace.RemoteSpace;
import org.jspace.SequentialSpace;
import org.jspace.Space;
import org.jspace.SpaceRepository;

public class Tests {

	public static void main(String[] args) throws UnknownHostException, IOException, InterruptedException {
		new RaceConditionTest();
	}
}

class RaceConditionTest {
	
	public RaceConditionTest() throws UnknownHostException, IOException, InterruptedException {
		// === server ===
		SpaceRepository sr = new SpaceRepository();
		sr.addGate("tcp://localhost:8080/?keep");
		
		Space space = new SequentialSpace();
		space.put("token");

		sr.add("space", space);
		
		// === client ===
		// a single client requesting the token/lock from different threads.
		RemoteSpace rs = new RemoteSpace("tcp://localhost:8080/space?keep");
		new Thread(() -> requester(rs)).start();
		new Thread(() -> requester(rs)).start();
		new Thread(() -> requester(rs)).start();
		new Thread(() -> requester(rs)).start();
		
	}

	private void requester(Space space) {
		while (true) {
			try {
				space.get(new ActualField("token"));
				space.put("token");
			} catch (InterruptedException e) {
				e.printStackTrace();
			}
		}
	}
}
```
