### PR TITLE
Prevent silent failure in `size()` method

### DIFF
--- a/common/src/main/java/org/jspace/RemoteSpace.java
+++ b/common/src/main/java/org/jspace/RemoteSpace.java
@@ -57,8 +57,7 @@ public class RemoteSpace implements Space {
 
 	@Override
 	public int size() {
-		// TODO Auto-generated method stub
-		return 0;
+		throw new NotImplementedException("RemoteSpace does not support the `size()` method");
 	}
 
 	@Override


### PR DESCRIPTION
**Description**
To prevent a silent failure when calling the `size()` method on a `RemoteSpace` an exception is thrown instead. 

**Motivation**
This makes it easier to debug why a size method call on a Space that may or may not be a remote space fails to produce correct results. It also more clearly communicates that this is intended behavior and not due to misuse or concurrency issues.