### PR TITLE
Improve handling of closing gates/spaces and connection lost

### DIFF
--- a/common/src/test/java/org/jspace/tests/TestCloseKeepConnection.java
+++ b/common/src/test/java/org/jspace/tests/TestCloseKeepConnection.java
@@ -1,0 +1,557 @@
+package org.jspace.tests;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.net.Socket;
+import java.util.HashSet;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.jspace.ActualField;
+import org.jspace.RemoteSpace;
+import org.jspace.SequentialSpace;
+import org.jspace.SpaceRepository;
+import org.jspace.gate.KeepClientGate;
+import org.junit.Test;
+
+/**
+ * Various tests for checking that everything is actually closed/handled
+ * properly when closing a keep connection (or the network connection is lost).
+ * Tests are mainly aimed at the client-side.
+ *
+ * Note: The tests pass and fail semi-randomly, so there must still be some concurrency bug.
+ *       Using debugging mode, adding print statements, using another process(-mode) or
+ *       changing timing in other ways affects the results.
+ *
+ * @author Bogoe
+ */
+public class TestCloseKeepConnection {
+
+	private static Object getField(Object obj, String name) {
+		try {
+			Field f = obj.getClass().getDeclaredField(name);
+			f.setAccessible(true);
+			return f.get(obj);
+		} catch (Exception e) {}
+		return null;
+	}
+
+	// @Test
+	public void testServerClose() {
+		int threadCount = Thread.activeCount();
+		HashSet<String> locks = new HashSet<>();
+		Object[] objects = new Object[3];
+		Thread serverThread = new Thread(() -> {
+			SpaceRepository repository = new SpaceRepository();
+			SequentialSpace space = new SequentialSpace();
+			repository.addGate("tcp://127.0.0.1:9991/?keep");
+			repository.add("space", space);
+			synchronized (locks) {
+				locks.add("serverReady");
+				locks.notifyAll();
+				while (!locks.contains("clientReady")) {
+					try {
+						locks.wait();
+					} catch (InterruptedException e) {}
+				}
+			}
+			repository.shutDown();
+			ExecutorService executor = (ExecutorService) getField(repository, "executor");
+			objects[0] = executor;
+			try {
+				executor.awaitTermination(10000, TimeUnit.MILLISECONDS);
+			} catch (InterruptedException e) {}
+			synchronized (locks) {
+				locks.add("serverClosed");
+				locks.notifyAll();
+			}
+		});
+		Thread clientThread = new Thread(() -> {
+			try {
+				synchronized (locks) {
+					while (!locks.contains("serverReady")) {
+						try {
+							locks.wait();
+						} catch (InterruptedException e) {}
+					}
+				}
+				RemoteSpace space = new RemoteSpace("tcp://127.0.0.1:9991/space?keep");
+				KeepClientGate gate = (KeepClientGate) space.getGate();
+				Socket socket = (Socket) getField(gate, "socket");
+				Thread outboxThread = (Thread) getField(gate, "outboxThread");
+				Thread inboxThread = (Thread) getField(gate, "inboxThread");
+				objects[1] = outboxThread;
+				objects[2] = inboxThread;
+				while (!socket.isConnected()) {
+					Thread.sleep(10);
+				}
+				synchronized (locks) {
+					locks.add("clientReady");
+					locks.notifyAll();
+					while (!locks.contains("serverClosed")) {
+						try {
+							locks.wait();
+						} catch (InterruptedException e) {}
+					}
+				}
+				outboxThread.join();
+				inboxThread.join();
+			} catch (IOException e) {
+
+			} catch (InterruptedException e) {
+
+			}
+		});
+		serverThread.start();
+		clientThread.start();
+		try {
+			serverThread.join();
+			clientThread.join();
+		} catch (InterruptedException e) {}
+		assertFalse("Server Thread did not terminate (within the time limit)", serverThread.isAlive());
+		assertFalse("Client Thread did not terminate (within the time limit)", clientThread.isAlive());
+		assertNotNull("Server Thread did not have an ExecutorService", objects[0]);
+		assertTrue("Server Thread threadpool was not shut down", ((ExecutorService) objects[0]).isShutdown());
+		assertNotNull("Client Thread did not have a thread for the outbox", objects[1]);
+		assertFalse("Client Outbox Thread did not terminate (within the time limit)", ((Thread) objects[1]).isAlive());
+		assertNotNull("Client Thread did not have a thread for the inbox", objects[2]);
+		assertFalse("Client Inbox Thread did not terminate (within the time limit)", ((Thread) objects[2]).isAlive());
+		assertEquals("The number of threads in the start does not match the number of threads in the end", threadCount, Thread.activeCount());
+	}
+
+	// @Test
+	public void testClientSendThenServerClose() {
+		int threadCount = Thread.activeCount();
+		HashSet<String> locks = new HashSet<>();
+		Object[] objects = new Object[4];
+		Thread serverThread = new Thread(() -> {
+			SpaceRepository repository = new SpaceRepository();
+			SequentialSpace space = new SequentialSpace();
+			repository.addGate("tcp://127.0.0.1:9992/?keep");
+			repository.add("space", space);
+			synchronized (locks) {
+				locks.add("serverReady");
+				locks.notifyAll();
+				while (!locks.contains("clientSent")) {
+					try {
+						locks.wait();
+					} catch (InterruptedException e) {}
+				}
+			}
+			repository.shutDown();
+			ExecutorService executor = (ExecutorService) getField(repository, "executor");
+			objects[0] = executor;
+			try {
+				executor.awaitTermination(10000, TimeUnit.MILLISECONDS);
+			} catch (InterruptedException e) {}
+			synchronized (locks) {
+				locks.add("serverClosed");
+				locks.notifyAll();
+			}
+		});
+		Thread clientThread = new Thread(() -> {
+			try {
+				synchronized (locks) {
+					while (!locks.contains("serverReady")) {
+						try {
+							locks.wait();
+						} catch (InterruptedException e) {}
+					}
+				}
+				RemoteSpace space = new RemoteSpace("tcp://127.0.0.1:9992/space?keep");
+				KeepClientGate gate = (KeepClientGate) space.getGate();
+				Thread outboxThread = (Thread) getField(gate, "outboxThread");
+				Thread inboxThread = (Thread) getField(gate, "inboxThread");
+				objects[1] = outboxThread;
+				objects[2] = inboxThread;
+				Thread requestThread = new Thread(() -> {
+					try {
+						space.get(new ActualField("Blocked Request"));
+						objects[3] = false;
+					} catch (InterruptedException e) {
+						objects[3] = true;
+					}
+				});
+				requestThread.start();
+				synchronized (locks) {
+					while (requestThread.getState() != Thread.State.WAITING) {
+						Thread.sleep(10);
+					}
+					locks.add("clientSent");
+					locks.notifyAll();
+					while (!locks.contains("serverClosed")) {
+						try {
+							locks.wait();
+						} catch (InterruptedException e) {}
+					}
+				}
+				outboxThread.join();
+				inboxThread.join();
+				requestThread.join();
+			} catch (IOException e) {
+
+			} catch (InterruptedException e) {
+
+			}
+		});
+		serverThread.start();
+		clientThread.start();
+		try {
+			serverThread.join();
+			clientThread.join();
+		} catch (InterruptedException e) {}
+		assertFalse("Server Thread did not terminate (within the time limit)", serverThread.isAlive());
+		assertFalse("Client Thread did not terminate (within the time limit)", clientThread.isAlive());
+		assertNotNull("Server Thread did not have an ExecutorService", objects[0]);
+		assertTrue("Server Thread threadpool was not shut down", ((ExecutorService) objects[0]).isShutdown());
+		assertNotNull("Client Thread did not have a thread for the outbox", objects[1]);
+		assertFalse("Client Outbox Thread did not terminate (within the time limit)", ((Thread) objects[1]).isAlive());
+		assertNotNull("Client Thread did not have a thread for the inbox", objects[2]);
+		assertFalse("Client Inbox Thread did not terminate (within the time limit)", ((Thread) objects[2]).isAlive());
+		assertNotNull("Client Thread, message did not succeeded and were interrupted", objects[3]);
+		assertTrue("Client Thread, message was not interrupted as expected", (Boolean) objects[3]);
+		assertEquals("The number of threads in the start does not match the number of threads in the end", threadCount, Thread.activeCount());
+	}
+
+	// @Test
+	public void testServerCloseThenClientSend() {
+		int threadCount = Thread.activeCount();
+		HashSet<String> locks = new HashSet<>();
+		Object[] objects = new Object[4];
+		Thread serverThread = new Thread(() -> {
+			SpaceRepository repository = new SpaceRepository();
+			SequentialSpace space = new SequentialSpace();
+			repository.addGate("tcp://127.0.0.1:9993/?keep");
+			repository.add("space", space);
+			synchronized (locks) {
+				locks.add("serverReady");
+				locks.notifyAll();
+				while (!locks.contains("clientReady")) {
+					try {
+						locks.wait();
+					} catch (InterruptedException e) {}
+				}
+			}
+			repository.shutDown();
+			ExecutorService executor = (ExecutorService) getField(repository, "executor");
+			objects[0] = executor;
+			try {
+				executor.awaitTermination(10000, TimeUnit.MILLISECONDS);
+			} catch (InterruptedException e) {}
+			synchronized (locks) {
+				locks.add("serverClosed");
+				locks.notifyAll();
+			}
+		});
+		Thread clientThread = new Thread(() -> {
+			try {
+				synchronized (locks) {
+					while (!locks.contains("serverReady")) {
+						try {
+							locks.wait();
+						} catch (InterruptedException e) {}
+					}
+				}
+				RemoteSpace space = new RemoteSpace("tcp://127.0.0.1:9993/space?keep");
+				KeepClientGate gate = (KeepClientGate) space.getGate();
+				Socket socket = (Socket) getField(gate, "socket");
+				Thread outboxThread = (Thread) getField(gate, "outboxThread");
+				Thread inboxThread = (Thread) getField(gate, "inboxThread");
+				objects[1] = outboxThread;
+				objects[2] = inboxThread;
+				while (!socket.isConnected()) {
+					Thread.sleep(10);
+				}
+				synchronized (locks) {
+					locks.add("clientReady");
+					locks.notifyAll();
+					while (!locks.contains("serverClosed")) {
+						try {
+							locks.wait();
+						} catch (InterruptedException e) {}
+					}
+				}
+				outboxThread.join();
+				inboxThread.join();
+				try {
+					space.put(new ActualField("Not send request"));
+					objects[3] = false;
+				} catch (InterruptedException e) {
+					objects[3] = true;
+				}
+			} catch (IOException e) {
+
+			} catch (InterruptedException e) {
+
+			}
+		});
+		serverThread.start();
+		clientThread.start();
+		try {
+			serverThread.join();
+			clientThread.join();
+		} catch (InterruptedException e) {}
+		assertFalse("Server Thread did not terminate (within the time limit)", serverThread.isAlive());
+		assertFalse("Client Thread did not terminate (within the time limit)", clientThread.isAlive());
+		assertNotNull("Server Thread did not have an ExecutorService", objects[0]);
+		assertTrue("Server Thread threadpool was not shut down", ((ExecutorService) objects[0]).isShutdown());
+		assertNotNull("Client Thread did not have a thread for the outbox", objects[1]);
+		assertFalse("Client Outbox Thread did not terminate (within the time limit)", ((Thread) objects[1]).isAlive());
+		assertNotNull("Client Thread did not have a thread for the inbox", objects[2]);
+		assertFalse("Client Inbox Thread did not terminate (within the time limit)", ((Thread) objects[2]).isAlive());
+		assertNotNull("Client Thread, message did not succeeded and were interrupted", objects[3]);
+		assertTrue("Client Thread, message was not interrupted as expected", (Boolean) objects[3]);
+		assertEquals("The number of threads in the start does not match the number of threads in the end", threadCount, Thread.activeCount());
+	}
+
+	// @Test
+	public void testClientClose() {
+		int threadCount = Thread.activeCount();
+		HashSet<String> locks = new HashSet<>();
+		Object[] objects = new Object[3];
+		Thread serverThread = new Thread(() -> {
+			SpaceRepository repository = new SpaceRepository();
+			SequentialSpace space = new SequentialSpace();
+			repository.addGate("tcp://127.0.0.1:9994/?keep");
+			repository.add("space", space);
+			synchronized (locks) {
+				locks.add("serverReady");
+				locks.notifyAll();
+				while (!locks.contains("clientClosed")) {
+					try {
+						locks.wait();
+					} catch (InterruptedException e) {}
+				}
+			}
+			repository.shutDown();
+			ExecutorService executor = (ExecutorService) getField(repository, "executor");
+			objects[0] = executor;
+			try {
+				executor.awaitTermination(10000, TimeUnit.MILLISECONDS);
+			} catch (InterruptedException e) {}
+		});
+		Thread clientThread = new Thread(() -> {
+			try {
+				synchronized (locks) {
+					while (!locks.contains("serverReady")) {
+						try {
+							locks.wait();
+						} catch (InterruptedException e) {}
+					}
+				}
+				RemoteSpace space = new RemoteSpace("tcp://127.0.0.1:9994/space?keep");
+				KeepClientGate gate = (KeepClientGate) space.getGate();
+				Socket socket = (Socket) getField(gate, "socket");
+				Thread outboxThread = (Thread) getField(gate, "outboxThread");
+				Thread inboxThread = (Thread) getField(gate, "inboxThread");
+				objects[1] = outboxThread;
+				objects[2] = inboxThread;
+				while (!socket.isConnected()) {
+					Thread.sleep(10);
+				}
+				space.close();
+				outboxThread.join();
+				inboxThread.join();
+				synchronized (locks) {
+					locks.add("clientClosed");
+					locks.notifyAll();
+				}
+			} catch (IOException e) {
+
+			} catch (InterruptedException e) {
+
+			}
+		});
+		serverThread.start();
+		clientThread.start();
+		try {
+			clientThread.join();
+			serverThread.join();
+		} catch (InterruptedException e) {}
+		assertFalse("Server Thread did not terminate (within the time limit)", serverThread.isAlive());
+		assertFalse("Client Thread did not terminate (within the time limit)", clientThread.isAlive());
+		assertNotNull("Server Thread did not have an ExecutorService", objects[0]);
+		assertTrue("Server Thread threadpool was not shut down", ((ExecutorService) objects[0]).isShutdown());
+		assertNotNull("Client Thread did not have a thread for the outbox", objects[1]);
+		assertFalse("Client Outbox Thread did not terminate (within the time limit)", ((Thread) objects[1]).isAlive());
+		assertNotNull("Client Thread did not have a thread for the inbox", objects[2]);
+		assertFalse("Client Inbox Thread did not terminate (within the time limit)", ((Thread) objects[2]).isAlive());
+		assertEquals("The number of threads in the start does not match the number of threads in the end", threadCount, Thread.activeCount());
+	}
+
+	// @Test
+	public void testClientSendThenClientClose() {
+		int threadCount = Thread.activeCount();
+		HashSet<String> locks = new HashSet<>();
+		Object[] objects = new Object[4];
+		Thread serverThread = new Thread(() -> {
+			SpaceRepository repository = new SpaceRepository();
+			SequentialSpace space = new SequentialSpace();
+			repository.addGate("tcp://127.0.0.1:9995/?keep");
+			repository.add("space", space);
+			synchronized (locks) {
+				locks.add("serverReady");
+				locks.notifyAll();
+				while (!locks.contains("clientClosed")) {
+					try {
+						locks.wait();
+					} catch (InterruptedException e) {}
+				}
+			}
+			repository.shutDown();
+			ExecutorService executor = (ExecutorService) getField(repository, "executor");
+			objects[0] = executor;
+			try {
+				executor.awaitTermination(10000, TimeUnit.MILLISECONDS);
+			} catch (InterruptedException e) {}
+		});
+		Thread clientThread = new Thread(() -> {
+			try {
+				synchronized (locks) {
+					while (!locks.contains("serverReady")) {
+						try {
+							locks.wait();
+						} catch (InterruptedException e) {}
+					}
+				}
+				RemoteSpace space = new RemoteSpace("tcp://127.0.0.1:9995/space?keep");
+				KeepClientGate gate = (KeepClientGate) space.getGate();
+				Thread outboxThread = (Thread) getField(gate, "outboxThread");
+				Thread inboxThread = (Thread) getField(gate, "inboxThread");
+				objects[1] = outboxThread;
+				objects[2] = inboxThread;
+				Thread requestThread = new Thread(() -> {
+					try {
+						space.get(new ActualField("Blocked Request"));
+						objects[3] = false;
+					} catch (InterruptedException e) {
+						objects[3] = true;
+					}
+				});
+				requestThread.start();
+				synchronized (locks) {
+					while (requestThread.getState() != Thread.State.WAITING) {
+						Thread.sleep(10);
+					}
+				}
+				space.close();
+				outboxThread.join();
+				inboxThread.join();
+				requestThread.join();
+				synchronized (locks) {
+					locks.add("clientClosed");
+					locks.notifyAll();
+				}
+			} catch (IOException e) {
+
+			} catch (InterruptedException e) {
+
+			}
+		});
+		serverThread.start();
+		clientThread.start();
+		try {
+			clientThread.join();
+			serverThread.join();
+		} catch (InterruptedException e) {}
+		assertFalse("Server Thread did not terminate (within the time limit)", serverThread.isAlive());
+		assertFalse("Client Thread did not terminate (within the time limit)", clientThread.isAlive());
+		assertNotNull("Server Thread did not have an ExecutorService", objects[0]);
+		assertTrue("Server Thread threadpool was not shut down", ((ExecutorService) objects[0]).isShutdown());
+		assertNotNull("Client Thread did not have a thread for the outbox", objects[1]);
+		assertFalse("Client Outbox Thread did not terminate (within the time limit)", ((Thread) objects[1]).isAlive());
+		assertNotNull("Client Thread did not have a thread for the inbox", objects[2]);
+		assertFalse("Client Inbox Thread did not terminate (within the time limit)", ((Thread) objects[2]).isAlive());
+		assertNotNull("Client Thread, message did not succeeded and were interrupted", objects[3]);
+		assertTrue("Client Thread, message was not interrupted as expected", (Boolean) objects[3]);
+		assertEquals("The number of threads in the start does not match the number of threads in the end", threadCount, Thread.activeCount());
+	}
+
+	@Test
+	public void testClientCloseThenClientSend() {
+		int threadCount = Thread.activeCount();
+		HashSet<String> locks = new HashSet<>();
+		Object[] objects = new Object[4];
+		Thread serverThread = new Thread(() -> {
+			SpaceRepository repository = new SpaceRepository();
+			SequentialSpace space = new SequentialSpace();
+			repository.addGate("tcp://127.0.0.1:9999/?keep");
+			repository.add("space", space);
+			synchronized (locks) {
+				locks.add("serverReady");
+				locks.notifyAll();
+				while (!locks.contains("clientClosed")) {
+					try {
+						locks.wait();
+					} catch (InterruptedException e) {}
+				}
+			}
+			repository.shutDown();
+			ExecutorService executor = (ExecutorService) getField(repository, "executor");
+			objects[0] = executor;
+			try {
+				executor.awaitTermination(10000, TimeUnit.MILLISECONDS);
+			} catch (InterruptedException e) {}
+		});
+		Thread clientThread = new Thread(() -> {
+			try {
+				synchronized (locks) {
+					while (!locks.contains("serverReady")) {
+						try {
+							locks.wait();
+						} catch (InterruptedException e) {}
+					}
+				}
+				RemoteSpace space = new RemoteSpace("tcp://127.0.0.1:9999/space?keep");
+				KeepClientGate gate = (KeepClientGate) space.getGate();
+				Socket socket = (Socket) getField(gate, "socket");
+				Thread outboxThread = (Thread) getField(gate, "outboxThread");
+				Thread inboxThread = (Thread) getField(gate, "inboxThread");
+				objects[1] = outboxThread;
+				objects[2] = inboxThread;
+				while (!socket.isConnected()) {
+					Thread.sleep(10);
+				}
+				space.close();
+				outboxThread.join();
+				inboxThread.join();
+				synchronized (locks) {
+					locks.add("clientClosed");
+					locks.notifyAll();
+				}
+				try {
+					space.put(new ActualField("Not send request"));
+					objects[3] = false;
+				} catch (InterruptedException e) {
+					objects[3] = true;
+				}
+			} catch (IOException e) {
+
+			} catch (InterruptedException e) {
+
+			}
+		});
+		serverThread.start();
+		clientThread.start();
+		try {
+			clientThread.join();
+			serverThread.join();
+		} catch (InterruptedException e) {}
+		assertFalse("Server Thread did not terminate (within the time limit)", serverThread.isAlive());
+		assertFalse("Client Thread did not terminate (within the time limit)", clientThread.isAlive());
+		assertNotNull("Server Thread did not have an ExecutorService", objects[0]);
+		assertTrue("Server Thread threadpool was not shut down", ((ExecutorService) objects[0]).isShutdown());
+		assertNotNull("Client Thread did not have a thread for the outbox", objects[1]);
+		assertFalse("Client Outbox Thread did not terminate (within the time limit)", ((Thread) objects[1]).isAlive());
+		assertNotNull("Client Thread did not have a thread for the inbox", objects[2]);
+		assertFalse("Client Inbox Thread did not terminate (within the time limit)", ((Thread) objects[2]).isAlive());
+		assertNotNull("Client Thread, message did not succeeded and were interrupted", objects[3]);
+		assertTrue("Client Thread, message was not interrupted as expected", (Boolean) objects[3]);
+		assertEquals("The number of threads in the start does not match the number of threads in the end", threadCount, Thread.activeCount());
+	}
+}

--- a/common/src/test/java/org/jspace/tests/TestRemoteSpace.java
+++ b/common/src/test/java/org/jspace/tests/TestRemoteSpace.java
@@ -31,8 +31,6 @@ import static org.junit.Assert.fail;
 import java.io.IOException;
 import java.net.UnknownHostException;
 
-import javax.swing.plaf.SliderUI;
-
 import org.jspace.ActualField;
 import org.jspace.RemoteSpace;
 import org.jspace.SequentialSpace;
@@ -222,7 +220,7 @@ public class TestRemoteSpace {
 		sr.closeGates();
 	}
 
-	//@Test
+	@Test
 	public void testCloseGate() {
 		String uri = "tcp://127.0.0.1:9994/?keep";
 		

--- a/common/src/test/java/org/jspace/tests/TestjSonMessageSerialization.java
+++ b/common/src/test/java/org/jspace/tests/TestjSonMessageSerialization.java
@@ -78,7 +78,6 @@ public class TestjSonMessageSerialization {
 				new URI("pspace://127.0.0.1:8080/test?KEEP")
 		);
 		String data = gson.toJson(message);
-		System.out.println(data);
 		ClientMessage obtained = gson.fromJson(data, ClientMessage.class);
 		assertEquals(message,obtained);
 	}


### PR DESCRIPTION
This pull request aims to fix the following issues in relation to closing gates/spaces or if one loses connection when using `KEEP` connections:
1. **OLD BEHAVIOR**: When `SpaceRepository.shutdown()` had been called, the `SpaceRepository` would in some cases still try to execute new tasks (listen for messages from a client or try to send a response) which throw `RejectedExecutionException`'s.
**NEW BEHAVIOR**: Tasks are no longer enqueued after `SpaceRepository.shutdown()` has been called.
2. **OLD BEHAVIOR**: After a `RemoteSpace` was closed (or connection was lost in some way), all threads that earlier had called `get`, `query`, `put`, ect. on a `RemoteSpace` would become stuck (they could be interrupted), because they never got an answer (no `InterruptedException` would be triggered).
**NEW BEHAVIOR**: When a `RemoteSpace` is closed, all waiting threads are now interrupted - they throw an `InterruptedException`.
3. **OLD BEHAVIOR**: Calling `get`, `query`, `put`, ect. on a `RemoteSpace` AFTER it is closed would make the calling thread stuck (it could be interrupted).
**NEW BEHAVIOR**: An `InterruptedException` is thrown.
4. **OLD BEHAVIOR**: When `RemoteSpace.close()` was called, the calling thread would become stuck, unless the thread responsible for receiving messages (`KeepClientGate.inboxHandlingMethod()`) got a message. The reason is that `BufferedReader.readLine()` takes a lock that is also needed for `BufferedReader.close()`.
**NEW BEHAVIOR**: The underlying socket is now closed first, which effectively also closes the `BufferReader`, so a `RemoteSpace` now can be closed without getting stuck.
5. **OLD BEHAVIOR**: If a `RemoteSpace` was connected to a `SpaceRepository`, then calling `SpaceRepository.shutdown()` would make the thread responsible for receiving messages (`KeepClientGate.inboxHandlingMethod()`) enter an infinite loop (due to the message was `null`) - effectively wasting one CPU core on nothing.
**NEW BEHAVIOR**: The thread now closes the gate automatically in this case, since a message being `null` means `EOF` (socket closed).

Very likely fixes issue #12.

I added a file `TestCloseKeepConnection.java` with six tests to test some of the things above. Each test runs one thread as server and one thread as client, concurrently (they both create even more threads). The tests work most of the time, but also fails too much to be called stable. One problem is that sometimes, some of the tests fail because there are more threads running after the test is finished than there where when it started. Another problem is that the tests sometimes get stuck (runs for ever), because the threads that are joined never terminate. I did not set a timeout, because that would not help making them stable. The second problem only seems to appear when running the tests via Maven in Eclipse, while the first problem is independent of how they are ran. Therefore, these tests are NOT ran when running all tests, because there might still be some concurrency issue.

Changes in:
- `SpaceRepository.java` covers point 1.
- `KeepClientGate.java` covers point 2, 3, 4 and 5.
- `Rendezvous.java` covers point 2.
- `TestRemoteSpace.java` one test was commented out (it never failed when I ran it).
- `TestjSonMessageSerialization.java` removed debug print.
- `TestCloseKeepConnection.java` new tests that are NOT included when running the tests, since they are unstable.